### PR TITLE
Add `avdl_exit` command, and some more syntax words for vim

### DIFF
--- a/engines/cengine/include/dd_game.h
+++ b/engines/cengine/include/dd_game.h
@@ -67,4 +67,6 @@ void avdl_cleanProjectLocation();
 // clear drawing depth buffer
 #define avdl_clear_depth() glClear(GL_DEPTH_BUFFER_BIT)
 
+#define avdl_exit() dd_flag_exit = 1;
+
 #endif

--- a/vim/syntax/avdl.vim
+++ b/vim/syntax/avdl.vim
@@ -60,6 +60,10 @@ syntax match avdlKeywords 'DD_INPUT_MOUSE_TYPE_PRESSED'
 syntax match avdlKeywords 'DD_INPUT_MOUSE_TYPE_RELEASED'
 syntax match avdlKeywords 'DD_STRING3D_ALIGN_CENTER'
 syntax match avdlKeywords 'avdl_clear_depth'
+syntax match avdlKeywords 'dd_clearColour'
+syntax match avdlKeywords 'dd_world_prepareReady'
+syntax match avdlKeywords 'avdl_setUniform1f'
+syntax match avdlKeywords 'avdl_exit'
 
 " primitive variable types
 syntax keyword avdlPrimitiveVariableTypes int float string char void


### PR DESCRIPTION
## Type

Select all that apply.

- [ ] Bugfix
- [x] Feature
- [ ] Other (please describe):

## New changes

Add the `avdl_exit` command, and a few more syntax words for syntax highlighting in vim
