### PR TITLE
`dd_image` is now separated from `dd_meshTexture`

### DIFF
--- a/engines/cengine/include/avdl_assetManager.h
+++ b/engines/cengine/include/avdl_assetManager.h
@@ -9,7 +9,7 @@
 #define AVDL_ASSETMANAGER_TEXTURE 4
 
 struct dd_meshToLoad {
-	struct dd_meshColour *mesh;
+	void *object;
 	int meshType;
 	char filename[400];
 	wchar_t filenameW[400];

--- a/engines/cengine/include/avdl_cengine.h
+++ b/engines/cengine/include/avdl_cengine.h
@@ -18,6 +18,7 @@
 #include "dd_vec4.h"
 #include "dd_mouse.h"
 #include "dd_string3d.h"
+#include "dd_image.h"
 #include "avdl_shaders.h"
 #include "dd_log.h"
 #include "avdl_data.h"

--- a/engines/cengine/include/dd_image.h
+++ b/engines/cengine/include/dd_image.h
@@ -8,7 +8,16 @@ struct dd_image {
 	int width, height;
 	float *pixels;
 	GLubyte *pixelsb;
+	char *assetName;
+	int openglContextId;
+
+	void (*bind)(struct dd_image *o);
+	void (*unbind)(struct dd_image *o);
+	void (*clean)(struct dd_image *o);
+	void (*set)(struct dd_image *o, const char *filename);
 };
+
+void dd_image_create(struct dd_image *o);
 
 #if defined(WIN32) || defined(_WIN32)
 void dd_image_load_bmp(struct dd_image *img, const wchar_t *filename);
@@ -17,7 +26,10 @@ void dd_image_load_bmp(struct dd_image *img, const char *filename);
 #endif
 void dd_image_to_opengl(struct dd_image *img);
 
-void dd_image_free(struct dd_image *img);
-void dd_image_draw(struct dd_image *img);
+void dd_image_bind(struct dd_image *o);
+void dd_image_unbind(struct dd_image *o);
+void dd_image_set(struct dd_image *o, const char *filename);
+
+void dd_image_clean(struct dd_image *o);
 
 #endif

--- a/engines/cengine/include/dd_mesh.h
+++ b/engines/cengine/include/dd_mesh.h
@@ -29,6 +29,8 @@ struct dd_mesh {
 	void (*set_primitive)(struct dd_mesh *m, enum dd_primitives shape);
 	void (*load)(struct dd_mesh *m, const char *filename);
 	void (*copy)(struct dd_mesh *, struct dd_mesh *);
+
+	void (*combine)(struct dd_mesh *dst, struct dd_mesh *src, float offsetX, float offsetY, float offsetZ);
 };
 
 // constructor
@@ -43,5 +45,6 @@ void dd_mesh_set_primitive(struct dd_mesh *m, enum dd_primitives shape);
 void dd_mesh_load(struct dd_mesh *m, const char *filename);
 
 void dd_mesh_copy(struct dd_mesh *dest, struct dd_mesh *src);
+void dd_mesh_combine(struct dd_mesh *dest, struct dd_mesh *src, float offsetX, float offsetY, float offsetZ);
 
 #endif /* MESH_H */

--- a/engines/cengine/include/dd_meshColour.h
+++ b/engines/cengine/include/dd_meshColour.h
@@ -25,4 +25,6 @@ void dd_meshColour_copy(struct dd_meshColour *dest, struct dd_meshColour *src);
 
 void dd_meshColour_set_colour(struct dd_meshColour *m, float r, float g, float b);
 
+void dd_meshColour_combine(struct dd_meshColour *dest, struct dd_meshColour *src, float offsetX, float offsetY, float offsetZ);
+
 #endif /* MESHCOLOUR_H */

--- a/engines/cengine/include/dd_meshTexture.h
+++ b/engines/cengine/include/dd_meshTexture.h
@@ -7,26 +7,22 @@
 
 struct dd_meshTexture {
 	struct dd_meshColour parent;
-	int dirtyImage;
-	struct dd_image img;
+
+	// texture to be used
+	struct dd_image *img;
+
+	// texture coordinates
 	int dirtyTextures;
 	float *t;
-	int openglContextId;
-	char *assetName;
+
 	void (*load)(struct dd_mesh *m, const char *filename);
-	void (*preloadTexture)(struct dd_mesh *m, char *filename);
-	int (*applyTexture)(struct dd_mesh *m);
-	void (*loadTexture)(struct dd_mesh *m, char *filename);
 	void (*set_primitive_texcoords)(struct dd_meshTexture *m, float offsetX, float offsetY, float sizeX, float sizeY);
-	void (*copyTexture)(struct dd_meshTexture *dest, struct dd_meshTexture *src);
+	void (*setTexture)(struct dd_meshTexture *o, struct dd_image *img);
 };
 
 // constructor
 void dd_meshTexture_create(struct dd_meshTexture *);
 void dd_meshTexture_load(struct dd_meshTexture *m, const char *filename);
-void dd_meshTexture_preloadTexture(struct dd_meshTexture *m, char *filename);
-int dd_meshTexture_applyTexture(struct dd_meshTexture *m);
-void dd_meshTexture_loadTexture(struct dd_meshTexture *m, char *filename);
 void dd_meshTexture_set_primitive(struct dd_meshTexture *m, enum dd_primitives shape);
 void dd_meshTexture_set_primitive_texcoords(struct dd_meshTexture *m, float offsetX, float offsetY, float sizeX, float sizeY);
 
@@ -34,6 +30,8 @@ void dd_meshTexture_draw(struct dd_meshTexture *m);
 void dd_meshTexture_clean(struct dd_meshTexture *m);
 
 void dd_meshTexture_copy(struct dd_meshTexture *dest, struct dd_meshTexture *src);
-void dd_meshTexture_copyTexture(struct dd_meshTexture *dest, struct dd_meshTexture *src);
+void dd_meshTexture_setTexture(struct dd_meshTexture *o, struct dd_image *tex);
+
+void dd_meshTexture_combine(struct dd_meshTexture *dst, struct dd_meshTexture *src, float offsetX, float offsetY, float offsetZ);
 
 #endif

--- a/engines/cengine/include/dd_string3d.h
+++ b/engines/cengine/include/dd_string3d.h
@@ -1,7 +1,7 @@
 #ifndef DD_TEXT_H
 #define DD_TEXT_H
 
-void dd_string3d_activate(const char *fontname);
+void dd_string3d_activate(const char *src, float fColumns, float fRows, float fWidth, float fHeight);
 int dd_string3d_isActive();
 
 void dd_string3d_init();
@@ -13,18 +13,23 @@ enum dd_string3d_align {
 };
 
 struct dd_string3d {
+
+	struct dd_dynamic_array textMeshes;
+
 	// Align
 	enum dd_string3d_align align;
 
 	float colorFront[3];
 	float colorBack[3];
 
+	int len;
+
+	void (*setText)(struct dd_string3d *, const char *text);
+
 	void (*setAlign)(struct dd_string3d *, enum dd_string3d_align);
-	void (*setColorFront)(struct dd_string3d *, float r, float g, float b);
-	void (*setColorBack)(struct dd_string3d *, float r, float g, float b);
-	void (*draw)(struct dd_string3d *, const char *text);
+	void (*draw)(struct dd_string3d *);
 	void (*drawInt)(struct dd_string3d *, int num);
-	void (*drawLimit)(struct dd_string3d *, const char *text, int limit);
+	void (*drawLimit)(struct dd_string3d *, int limit);
 
 	void (*clean)(struct dd_string3d *);
 };
@@ -32,13 +37,12 @@ struct dd_string3d {
 void dd_string3d_create(struct dd_string3d *o);
 void dd_string3d_setAlign(struct dd_string3d *o, enum dd_string3d_align al);
 
-void dd_string3d_setColorFront(struct dd_string3d *, float r, float g, float b);
-void dd_string3d_setColorBack(struct dd_string3d *, float r, float g, float b);
-
-void dd_string3d_draw(struct dd_string3d *o, const char* text);
+void dd_string3d_draw(struct dd_string3d *o);
 void dd_string3d_drawInt(struct dd_string3d *o, int num);
-void dd_string3d_drawLimit(struct dd_string3d *o, const char* text, int limit);
+void dd_string3d_drawLimit(struct dd_string3d *o, int limit);
 
 void dd_string3d_clean(struct dd_string3d *o);
+
+void dd_string3d_setText(struct dd_string3d *o, const char *text);
 
 #endif

--- a/engines/cengine/src/avdl_assetManager.c
+++ b/engines/cengine/src/avdl_assetManager.c
@@ -57,7 +57,7 @@ void avdl_assetManager_add(void *object, int meshType, const char *assetname) {
 
 	//printf("add asset: %s\n", assetname);
 	struct dd_meshToLoad meshToLoad;
-	meshToLoad.mesh = object;
+	meshToLoad.object = object;
 	meshToLoad.meshType = meshType;
 	#if defined(_WIN32) || defined(WIN32)
 	wcscpy(meshToLoad.filenameW, avdl_getProjectLocation());
@@ -112,7 +112,7 @@ void avdl_assetManager_loadAssets() {
 
 		// load texture
 		if (m->meshType == AVDL_ASSETMANAGER_TEXTURE) {
-			struct dd_meshTexture *mesh = m->mesh;
+			struct dd_image *mesh = m->object;
 
 			jmethodID MethodID = (*(*env)->GetStaticMethodID)(env, clazz, "ReadBitmap", "(Ljava/lang/String;)[Ljava/lang/Object;");
 			jstring *parameter = (*env)->NewStringUTF(env, m->filename);
@@ -153,9 +153,9 @@ void avdl_assetManager_loadAssets() {
 				(*env)->ReleaseIntArrayElements(env, pixels, pixelValues, JNI_ABORT);
 
 				pthread_mutex_lock(&updateDrawMutex);
-				mesh->img.width = width;
-				mesh->img.height = height;
-				mesh->img.pixelsb = pixelsb;
+				mesh->width = width;
+				mesh->height = height;
+				mesh->pixelsb = pixelsb;
 				pthread_mutex_unlock(&updateDrawMutex);
 			}
 			//dd_log("done: %s", m->filename);
@@ -183,7 +183,7 @@ void avdl_assetManager_loadAssets() {
 			 */
 			if (result && (m->meshType == AVDL_ASSETMANAGER_MESHTEXTURE)) {
 
-				struct dd_meshTexture *mesh = m->mesh;
+				struct dd_meshTexture *mesh = m->object;
 
 				// the first object describes the size of the texture
 				const jintArray pos  = (*(*env)->GetObjectArrayElement)(env, result, 0);
@@ -223,7 +223,7 @@ void avdl_assetManager_loadAssets() {
 			else
 			if (result && (m->meshType == AVDL_ASSETMANAGER_MESHCOLOUR)) {
 
-				struct dd_meshColour *mesh = m->mesh;
+				struct dd_meshColour *mesh = m->object;
 
 				// the first object describes the size of the texture
 				const jintArray pos  = (*(*env)->GetObjectArrayElement)(env, result, 0);
@@ -257,7 +257,7 @@ void avdl_assetManager_loadAssets() {
 			else
 			if (result) {
 
-				struct dd_mesh *mesh = m->mesh;
+				struct dd_mesh *mesh = m->object;
 
 				// the first object describes the size of the texture
 				const jintArray pos  = (*(*env)->GetObjectArrayElement)(env, result, 0);
@@ -287,18 +287,18 @@ void avdl_assetManager_loadAssets() {
 		#else
 		// load texture
 		if (m->meshType == AVDL_ASSETMANAGER_TEXTURE) {
-			struct dd_meshTexture *mesh = m->mesh;
+			struct dd_image *mesh = m->object;
 			#if defined(_WIN32) || defined(WIN32)
-			dd_image_load_bmp(&mesh->img, m->filenameW);
+			dd_image_load_bmp(mesh, m->filenameW);
 			#else
-			dd_image_load_bmp(&mesh->img, m->filename);
+			dd_image_load_bmp(mesh, m->filename);
 			#endif
 		}
 		// load mesh
 		else {
 			// mesh
 			if (m->meshType == AVDL_ASSETMANAGER_MESH) {
-				struct dd_mesh *mesh = m->mesh;
+				struct dd_mesh *mesh = m->object;
 				dd_mesh_clean(mesh);
 				struct dd_loaded_mesh lm;
 				#if defined(_WIN32) || defined(WIN32)
@@ -313,7 +313,7 @@ void avdl_assetManager_loadAssets() {
 			else
 			// mesh colour
 			if (m->meshType == AVDL_ASSETMANAGER_MESHCOLOUR) {
-				struct dd_meshColour *mesh = m->mesh;
+				struct dd_meshColour *mesh = m->object;
 				dd_meshColour_clean(mesh);
 				struct dd_loaded_mesh lm;
 				#if defined(_WIN32) || defined(WIN32)
@@ -332,7 +332,7 @@ void avdl_assetManager_loadAssets() {
 			else
 			// mesh texture
 			if (m->meshType == AVDL_ASSETMANAGER_MESHTEXTURE) {
-				struct dd_meshTexture *mesh = m->mesh;
+				struct dd_meshTexture *mesh = m->object;
 				dd_meshTexture_clean(mesh);
 				struct dd_loaded_mesh lm;
 				#if defined(_WIN32) || defined(WIN32)

--- a/engines/cengine/src/avdl_shaders.c
+++ b/engines/cengine/src/avdl_shaders.c
@@ -309,29 +309,34 @@ const char *avdl_shaderDefault_fragment =
 
 const char *avdl_shaderFont_vertex =
 "AVDL_IN vec4 position;\n"
+"AVDL_IN vec2 texCoord;\n"
 
 "uniform vec3 colorFront;\n"
 "uniform vec3 colorBack;\n"
 "uniform mat4 matrix;\n"
 
 "AVDL_OUT vec4 outColour;\n"
+"AVDL_OUT vec2 outTexCoord;\n"
 
 "void main() {\n"
 "	gl_Position = matrix *position;\n"
-"	if (position.z >= 0.0) {\n"
-"		outColour = vec4(colorFront, 1);\n"
-"	}\n"
-"	else {\n"
-"		outColour = vec4(colorBack, 1);\n"
-"	}\n"
+"	outColour = vec4(1.0f, 1.0f, 1.0f, 1.0f);\n"
+"	outTexCoord  = texCoord;\n"
 "}\n"
 ;
 
 const char *avdl_shaderFont_fragment =
 "AVDL_IN vec4 outColour;\n"
+"AVDL_IN vec2 outTexCoord;\n"
+
+"uniform sampler2D image;\n"
 
 "void main() {\n"
-"	avdl_frag_color = outColour;\n"
+"	vec4 finalCol = avdl_texture(image, outTexCoord);\n"
+"	if (finalCol.r < 0.05 && finalCol.g < 0.05 && finalCol.b < 0.05) {\n"
+"		discard;\n"
+"	}\n"
+"	avdl_frag_color = finalCol;\n"
 "}\n"
 ;
 

--- a/engines/cengine/src/dd_mesh.c
+++ b/engines/cengine/src/dd_mesh.c
@@ -5,6 +5,7 @@
 #include <string.h>
 #include "avdl_assetManager.h"
 #include "dd_log.h"
+#include <stdlib.h>
 
 extern GLuint defaultProgram;
 extern GLuint currentProgram;
@@ -126,4 +127,14 @@ void dd_mesh_copy(struct dd_mesh *dest, struct dd_mesh *src) {
 	dest->v = malloc(src->vcount *sizeof(float) *3);
 	memcpy(dest->v, src->v, sizeof(float) *src->vcount *3);
 	dest->dirtyVertices = 1;
+}
+
+void dd_mesh_combine(struct dd_mesh *dst, struct dd_mesh *src, float offsetX, float offsetY, float offsetZ) {
+	dst->v = realloc(dst->v, (dst->vcount +src->vcount) *sizeof(float) *3);
+	for (int i = dst->vcount *3; i < (dst->vcount +src->vcount) *3; i += 3) {
+		dst->v[i+0] = src->v[(i+0) -(dst->vcount *3)] +offsetX;
+		dst->v[i+1] = src->v[(i+1) -(dst->vcount *3)] +offsetY;
+		dst->v[i+2] = src->v[(i+2) -(dst->vcount *3)] +offsetZ;
+	}
+	dst->vcount += src->vcount;
 }

--- a/engines/cengine/src/dd_string3d.c
+++ b/engines/cengine/src/dd_string3d.c
@@ -3,17 +3,28 @@
 #include <string.h>
 #include "avdl_cengine.h"
 
-static struct dd_mesh letter[26];
-static struct dd_mesh number[26];
+static struct dd_image fontTexture;
 extern GLuint fontProgram;
 extern GLuint defaultProgram;
 extern GLuint currentProgram;
 
 static int isActive = 0;
 static const char *fontname = 0;
-void dd_string3d_activate(const char *src) {
+
+static int fontColumns = 1;
+static int fontRows = 1;
+static float fontWidth = 1.0;
+static float fontHeight = 1.0;
+
+void dd_string3d_activate(const char *src, float fColumns, float fRows, float fWidth, float fHeight) {
 	isActive = 1;
 	fontname = src;
+
+	fontColumns = fColumns;
+	fontRows = fRows;
+	fontWidth = fWidth;
+	fontHeight = fHeight;
+
 }
 
 int dd_string3d_isActive() {
@@ -22,73 +33,17 @@ int dd_string3d_isActive() {
 
 extern struct dd_matrix matPerspective;
 
-static void dd_string3d_drawLetter(struct dd_string3d *font, struct dd_mesh *o) {
-	int previousProgram;
-	glGetIntegerv(GL_CURRENT_PROGRAM, &previousProgram);
-	glUseProgram(fontProgram);
-	GLint MatrixID = glGetUniformLocation(fontProgram, "matrix");
-	glUniformMatrix4fv(MatrixID, 1, GL_FALSE, (float *)dd_matrix_globalGet());
-
-	glEnableVertexAttribArray(0);
-	glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 0, o->v);
-
-	GLint loc = glGetUniformLocation(fontProgram, "colorFront");
-	if (loc != -1)
-	{
-		glUniform3f(loc, font->colorFront[0], font->colorFront[1], font->colorFront[2]);
-	}
-
-	loc = glGetUniformLocation(fontProgram, "colorBack");
-	if (loc != -1)
-	{
-		glUniform3f(loc, font->colorBack[0], font->colorBack[1], font->colorBack[2]);
-	}
-
-	glDrawArrays(GL_TRIANGLES, 0, o->vcount);
-
-	glDisableVertexAttribArray(0);
-	glUseProgram(previousProgram);
-}
-
 void dd_string3d_init() {
 
-	// Make sure fontname is within the limits
-	if (strlen(fontname) >= 500) {
-		dd_log("avdl: string3d: font path should have less than 500 characters");
-		return;
-	}
-
-	// Prepare buffer that will swap the characters to load the files
-	char buffer[500];
-	strcpy(buffer, fontname);
-	char *special = buffer;
-
-	// Find the special (?) character
-	while (special[0] != '?') {
-		special++;
-		if (special -buffer >= strlen(buffer)) {
-			dd_log("avdl: string3d: no special (?) character found");
-			return;
-		}
-	}
-
-	// Load letters
-	for (int i = 'a'; i <= 'z'; i++) {
-		special[0] = i;
-		dd_mesh_create(&letter[i-'a']);
-		letter[i-'a'].load(&letter[i-'a'], buffer);
-	}
-
-	// Load numbers
-	for (int i = '0'; i <= '9'; i++) {
-		special[0] = i;
-		dd_mesh_create(&number[i-'0']);
-		number[i-'0'].load(&number[i-'0'], buffer);
-	}
+	dd_image_create(&fontTexture);
+	dd_image_set(&fontTexture, fontname);
 
 } // string3d init
 
 void dd_string3d_create(struct dd_string3d *o) {
+
+	dd_da_init(&o->textMeshes, sizeof(struct dd_meshTexture));
+
 	o->align = DD_STRING3D_ALIGN_LEFT;
 	o->colorFront[0] = 1.0;
 	o->colorFront[1] = 1.0;
@@ -96,14 +51,14 @@ void dd_string3d_create(struct dd_string3d *o) {
 	o->colorBack[0] = 0.0;
 	o->colorBack[1] = 0.0;
 	o->colorBack[2] = 0.0;
+	o->len = 0;
 
 	o->setAlign = dd_string3d_setAlign;
-	o->setColorFront = dd_string3d_setColorFront;
-	o->setColorBack = dd_string3d_setColorBack;
 	o->clean = dd_string3d_clean;
 	o->draw = dd_string3d_draw;
 	o->drawInt = dd_string3d_drawInt;
 	o->drawLimit = dd_string3d_drawLimit;
+	o->setText = dd_string3d_setText;
 
 }
 
@@ -111,82 +66,94 @@ void dd_string3d_setAlign(struct dd_string3d *o, enum dd_string3d_align al) {
 	o->align = al;
 }
 
-void dd_string3d_draw(struct dd_string3d *o, const char* text) {
-	dd_string3d_drawLimit(o, text, 0);
+void dd_string3d_draw(struct dd_string3d *o) {
+	dd_string3d_drawLimit(o, 0);
 }
 
 void dd_string3d_drawInt(struct dd_string3d *o, int num) {
+	/*
 	char numberString[11];
 	snprintf(numberString, 11, "%d", num);
 	dd_string3d_draw(o, numberString);
+	*/
 }
 
-void dd_string3d_drawLimit(struct dd_string3d *o, const char* text, int limit) {
+void dd_string3d_drawLimit(struct dd_string3d *o, int limit) {
 
-	if (limit <= 0) {
-		limit = strlen(text);
-	}
+	if (o->textMeshes.elements > 0) {
+		struct dd_meshTexture *m = dd_da_get(&o->textMeshes, 0);
 
-	int lines;
-	lines = 1 +(strlen(text) /limit);
-	if (strlen(text) %limit == 0) {
-		lines--;
-	}
-
-	//const char *currentText = text;
-	for (int i = 0; i < lines; i++) {
 		dd_matrix_push();
-
-		int lineWidth = dd_math_min(strlen(text), limit);
-		dd_translatef(0, -1 *i, 0);
 
 		switch (o->align) {
 		case DD_STRING3D_ALIGN_LEFT:
 			break;
 		case DD_STRING3D_ALIGN_CENTER:
-			dd_translatef(-(lineWidth *0.5)/2 +0.25, 0, 0);
+			dd_translatef(0.5 -(o->len *0.5), 0, 0);
 			break;
 		case DD_STRING3D_ALIGN_RIGHT:
-			dd_translatef(-(lineWidth *0.5), 0, 0);
+			dd_translatef(0.5 -(o->len), 0, 0);
 			break;
 		}
 
-		int j = 0;
-		const char *currentLetter = text +(i*limit);
-		while (currentLetter[0] != '\0' && j < limit) {
+		int previousProgram;
+		glGetIntegerv(GL_CURRENT_PROGRAM, &previousProgram);
+		glUseProgram(fontProgram);
+		GLint MatrixID = glGetUniformLocation(fontProgram, "matrix");
+		glUniformMatrix4fv(MatrixID, 1, GL_FALSE, (float *)dd_matrix_globalGet());
 
-			if (currentLetter[0] >= 'A' && currentLetter[0] <= 'Z') {
-				dd_string3d_drawLetter(o, &letter[currentLetter[0]-'A']);
-			}
-			else
-			// Draw letter
-			if (currentLetter[0] >= 'a' && currentLetter[0] <= 'z') {
-				dd_string3d_drawLetter(o, &letter[currentLetter[0]-'a']);
-			}
-			else
-			// Draw number
-			if (currentLetter[0] >= '0' && currentLetter[0] <= '9') {
-				dd_string3d_drawLetter(o, &number[currentLetter[0]-'0']);
-			}
-			dd_translatef(0.5, 0, 0);
-			currentLetter++;
-			j++;
-		}
+		dd_meshTexture_draw(m);
+
+		glUseProgram(previousProgram);
 		dd_matrix_pop();
 	}
 }
 
 void dd_string3d_clean(struct dd_string3d *o) {
+	dd_da_free(&o->textMeshes);
 }
 
-void dd_string3d_setColorFront(struct dd_string3d *o, float r, float g, float b) {
-	o->colorFront[0] = r;
-	o->colorFront[1] = g;
-	o->colorFront[2] = b;
-}
+void dd_string3d_setText(struct dd_string3d *o, const char *text) {
 
-void dd_string3d_setColorBack(struct dd_string3d *o, float r, float g, float b) {
-	o->colorBack[0] = r;
-	o->colorBack[1] = g;
-	o->colorBack[2] = b;
+	// empty previous text meshes (if any)
+	for (int i = 0; i < o->textMeshes.elements; i++) {
+		struct dd_meshTexture *p;
+		p = dd_da_get(&o->textMeshes, i);
+		dd_meshTexture_clean(p);
+	}
+	dd_da_empty(&o->textMeshes);
+
+	// add new text meshes
+	struct dd_meshTexture m;
+	dd_da_add(&o->textMeshes, &m);
+
+	struct dd_meshTexture *p;
+	p = dd_da_get(&o->textMeshes, 0);
+
+	dd_meshTexture_create(p);
+	dd_meshTexture_setTexture(p, &fontTexture);
+
+	o->len = strlen(text);
+
+	int len = strlen(text);
+	for (int i = 0; i < len; i++) {
+
+		struct dd_meshTexture m2;
+		dd_meshTexture_create(&m2);
+		dd_meshTexture_set_primitive(&m2, DD_PRIMITIVE_RECTANGLE);
+		dd_meshColour_set_colour(&m2, 1, 1, 1);
+
+		// for each letter, create a mesh and position it
+		int offsetX = (text[i] -32) %14;
+		int offsetY = 6 -((text[i] -32) /14);
+		dd_meshTexture_set_primitive_texcoords(&m2,
+			((fontWidth /fontColumns) *offsetX),
+			(1.0 -fontHeight) +((fontHeight /fontRows) *offsetY),
+			(fontWidth /fontColumns),
+			(fontHeight /fontRows)
+		);
+
+		dd_meshTexture_combine(p, &m2, i *1, 0, 0);
+	}
+
 }

--- a/src/avdl_struct_table.c
+++ b/src/avdl_struct_table.c
@@ -39,6 +39,12 @@ void struct_table_init() {
 	struct_table_push_member("loadTexture", DD_VARIABLE_TYPE_FUNCTION, 0, 0);
 	struct_table_push_member("set_primitive_texcoords", DD_VARIABLE_TYPE_FUNCTION, 0, 0);
 	struct_table_push_member("copyTexture", DD_VARIABLE_TYPE_FUNCTION, 0, 0);
+	struct_table_push_member("setTexture", DD_VARIABLE_TYPE_FUNCTION, 0, 0);
+	struct_table_push("dd_image", 0);
+	struct_table_push_member("set", DD_VARIABLE_TYPE_FUNCTION, 0, 0);
+	struct_table_push_member("bind", DD_VARIABLE_TYPE_FUNCTION, 0, 0);
+	struct_table_push_member("unbind", DD_VARIABLE_TYPE_FUNCTION, 0, 0);
+	struct_table_push_member("clean", DD_VARIABLE_TYPE_FUNCTION, 0, 0);
 	struct_table_push("dd_sound", 0);
 	struct_table_push_member("load", DD_VARIABLE_TYPE_FUNCTION, 0, 0);
 	struct_table_push_member("clean", DD_VARIABLE_TYPE_FUNCTION, 0, 0);
@@ -53,8 +59,7 @@ void struct_table_init() {
 	struct_table_push_member("getZ", DD_VARIABLE_TYPE_FUNCTION, 0, 0);
 	struct_table_push("dd_string3d", 0);
 	struct_table_push_member("setAlign", DD_VARIABLE_TYPE_FUNCTION, 0, 0);
-	struct_table_push_member("setColorFront", DD_VARIABLE_TYPE_FUNCTION, 0, 0);
-	struct_table_push_member("setColorBack", DD_VARIABLE_TYPE_FUNCTION, 0, 0);
+	struct_table_push_member("setText", DD_VARIABLE_TYPE_FUNCTION, 0, 0);
 	struct_table_push_member("draw", DD_VARIABLE_TYPE_FUNCTION, 0, 0);
 	struct_table_push_member("drawInt", DD_VARIABLE_TYPE_FUNCTION, 0, 0);
 	struct_table_push_member("drawLimit", DD_VARIABLE_TYPE_FUNCTION, 0, 0);


### PR DESCRIPTION
## Type

Select all that apply.

- [ ] Bugfix
- [x] Feature
- [ ] Other (please describe):

## New changes

Separates textures from textured meshes. This allows the user to load textures and share them between multiple meshes.
Also changed the build-in text renderer to use 2D rendered text on 3D planes, instead of 3D meshes for each glyph.