### PR TITLE
Re-add int drawing and ability to set kerning

### DIFF
--- a/engines/cengine/include/dd_string3d.h
+++ b/engines/cengine/include/dd_string3d.h
@@ -52,4 +52,6 @@ void dd_string3d_clean(struct dd_string3d *o);
 
 void dd_string3d_setText(struct dd_string3d *o, const char *text);
 
+void dd_string3d_setKerning(float nkerning);
+
 #endif


### PR DESCRIPTION
## Type

Select all that apply.

- [ ] Bugfix
- [x] Feature
- [ ] Other (please describe):

## New changes

Allow `dd_string3d` to draw dynamic `int` values every frame, after the change from 3D models to 2D textures on planes.
