### PR TITLE
Increase struct member count, as a temporary measure

### DIFF
--- a/include/avdl_struct_table.h
+++ b/include/avdl_struct_table.h
@@ -6,7 +6,7 @@
 
 // struct sizes
 #define DD_STRUCT_TABLE_NAME_SIZE 100
-#define DD_STRUCT_TABLE_MEMBER_TOTAL 100
+#define DD_STRUCT_TABLE_MEMBER_TOTAL 150
 
 // struct members
 struct struct_table_entry_member {


### PR DESCRIPTION
## Description

Increase the number of struct members. Ideally an unlimited amount of members should be allowed, but this is a temporary solution until the bigger solution is implemented.