### PR TITLE
Make sure vertex and fragment shaders compile on the same version

### DIFF
--- a/engines/cengine/src/dd_image.c
+++ b/engines/cengine/src/dd_image.c
@@ -3,6 +3,7 @@
 #include <stdio.h>
 #include "dd_log.h"
 #include "avdl_assetManager.h"
+#include <errno.h>
 
 void dd_image_create(struct dd_image *o) {
 	o->tex = 0;
@@ -56,7 +57,7 @@ void dd_image_load_bmp(struct dd_image *img, const char *filename) {
 	#else
 	FILE *f = fopen(filename, "rb");
 	if (!f) {
-		dd_log("dd_image_load_bmp: error opening file: '%s'", filename);
+		dd_log("dd_image_load_bmp: error opening file: '%s': '%s'", filename, strerror(errno));
 		exit(-1);
 	}
 	#endif


### PR DESCRIPTION
## Description

Previously, the vertex and fragment shaders were compiled independently on each supported version. This means it was possibly to compile the vertex shader on one version, and the fragment shader in another.

This PR makes sure that both shaders have to succeed on the same version, before attempting to create a program.