### PR TITLE
Add support for `.cpp` files and primitive achievements

### DIFF
--- a/engines/cengine/include/avdl_achievements.h
+++ b/engines/cengine/include/avdl_achievements.h
@@ -1,0 +1,21 @@
+#ifndef AVDL_ACHIEVEMENTS_H
+#define AVDL_ACHIEVEMENTS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct avdl_achievements {
+	int x;
+};
+
+struct avdl_achievements *avdl_achievements_create();
+void avdl_achievements_clean(struct avdl_achievements *o);
+
+void avdl_achievements_set(struct avdl_achievements *o, const char *achievementId);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/engines/cengine/include/avdl_cengine.h
+++ b/engines/cengine/include/avdl_cengine.h
@@ -26,5 +26,7 @@
 #include "avdl_assetManager.h"
 #include "avdl_particle_system.h"
 #include "avdl_localisation.h"
+#include "avdl_steam.h"
+#include "avdl_achievements.h"
 
 int dd_main(int argc, char *argv[]);

--- a/engines/cengine/include/avdl_steam.h
+++ b/engines/cengine/include/avdl_steam.h
@@ -1,0 +1,16 @@
+#ifndef AVDL_STEAM_H
+#define AVDL_STEAM_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int avdl_steam_init();
+void avdl_steam_update();
+void avdl_steam_shutdown();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/engines/cengine/makefile
+++ b/engines/cengine/makefile
@@ -25,6 +25,8 @@ DIRECTORIES=${DIRECTORY_BUILD} ${DIRECTORY_OBJ}
 #
 SRC=$(wildcard ${DIRECTORY_SRC}/*.c)
 OBJ=${SRC:${DIRECTORY_SRC}/%.c=${DIRECTORY_OBJ}/%.o}
+SRC_CPP=$(wildcard ${DIRECTORY_SRC}/*.cpp)
+OBJ_CPP=${SRC:${DIRECTORY_SRC}/%.cpp=${DIRECTORY_OBJ}/%.o}
 HEADERS=$(wildcard include/*.h)
 
 #
@@ -82,6 +84,7 @@ ${INSTALL_DIRS}:
 install: ${DIRECTORIES} ${INSTALL_DIRS} #${STATIC_OUT}
 	install -m644 ${HEADERS} ${DESTDIR}${prefix}/include
 	install -m644 ${SRC} ${DESTDIR}${prefix}/share/avdl/cengine
+	install -m644 ${SRC_CPP} ${DESTDIR}${prefix}/share/avdl/cengine
 	#install -m755 ${STATIC_OUT} ${DESTDIR}${prefix}/lib
 
 #

--- a/engines/cengine/src/avdl_achievements.c
+++ b/engines/cengine/src/avdl_achievements.c
@@ -1,0 +1,11 @@
+#include "avdl_achievements.h"
+
+struct avdl_achievements *avdl_achievements_create() {
+	return 0;
+}
+
+void avdl_achievements_clean(struct avdl_achievements *o) {
+}
+
+void avdl_achievements_set(struct avdl_achievements *o, const char *achievementId) {
+}

--- a/engines/cengine/src/avdl_achievements_steam.cpp
+++ b/engines/cengine/src/avdl_achievements_steam.cpp
@@ -1,0 +1,18 @@
+#include "avdl_achievements.h"
+#include "steam_api.h"
+
+struct avdl_achievements *avdl_achievements_create() {
+	if (!SteamUserStats()->RequestCurrentStats()) {
+		printf("avdl: failed to initialise achievements\n");
+	}
+	return 0;
+}
+
+void avdl_achievements_clean(struct avdl_achievements *o) {
+}
+
+void avdl_achievements_set(struct avdl_achievements *o, const char *achievementId) {
+	if (!SteamUserStats()->SetAchievement(achievementId)) {
+		printf("avdl: failed to set steam achievement: '%s'\n", achievementId);
+	}
+}

--- a/engines/cengine/src/avdl_steam.c
+++ b/engines/cengine/src/avdl_steam.c
@@ -1,0 +1,11 @@
+#include "avdl_steam.h"
+
+int avdl_steam_init() {
+	return 1;
+}
+
+void avdl_steam_update() {
+}
+
+void avdl_steam_shutdown() {
+}

--- a/engines/cengine/src/avdl_steam_cpp.cpp
+++ b/engines/cengine/src/avdl_steam_cpp.cpp
@@ -1,0 +1,15 @@
+#include "avdl_steam.h"
+#include <stdio.h>
+#include "steam_api.h"
+
+int avdl_steam_init() {
+	return SteamAPI_Init();
+}
+
+void avdl_steam_update() {
+	SteamAPI_RunCallbacks();
+}
+
+void avdl_steam_shutdown() {
+	SteamAPI_Shutdown();
+}

--- a/engines/cengine/src/main_cpp.cpp
+++ b/engines/cengine/src/main_cpp.cpp
@@ -1,0 +1,6 @@
+
+extern "C" int dd_main(int argc, char *argv[]);
+
+int main(int argc, char *argv[]) {
+	return dd_main(argc, argv);
+}

--- a/makefile
+++ b/makefile
@@ -45,6 +45,7 @@ HEADERS=$(widcard include/*.h)
 # engine files
 #
 ENGINE_FILES_SRC=$(wildcard engines/cengine/src/*.c)
+ENGINE_FILES_SRC_CPP=$(wildcard engines/cengine/src/*.cpp)
 ENGINE_FILES_HEADERS=$(wildcard engines/cengine/include/*.h)
 ENGINE_FILES_ANDROID=$(ENGINE_FILES_HEADERS:engines/cengine/include/%.h=engine/%.h)\
 	$(ENGINE_FILES_SRC:engines/cengine/src/%.c=engine/%.c)

--- a/src/avdl_parser_cglut.c
+++ b/src/avdl_parser_cglut.c
@@ -281,11 +281,6 @@ static void print_command_function(FILE *fd, struct ast_node *n) {
 	}
 
 	fprintf(fd, "}\n");
-
-	// `dd_gameInit` is the "main" function, where everything begins
-	if (strcmp(funcname->lex, "dd_gameInit") == 0) {
-		fprintf(fd, "int main(int argc, char *argv[]) {dd_main(argc, argv);}\n");
-	}
 }
 
 static void print_command_classFunction(FILE *fd, struct ast_node *n) {


### PR DESCRIPTION
## Description

Adds ability to add `C++` components to a game. This is achieved by compiling the game itself in `C`, and any add-ons with `C++`, and linking everything together.

Also adds a very simple implementation of Valve's Steamworks API, which is implemented in `C++` and uses the system above to work. The first feature added is a simple Achievements system. This can be optionally added to a game using the `--steam` command.