### PR TITLE
Organised lexer, also removed `fseek` and `ftell` functionality

### DIFF
--- a/include/avdl_lexer.h
+++ b/include/avdl_lexer.h
@@ -1,6 +1,9 @@
 #ifndef AVDL_LEXER_H
 #define AVDL_LEXER_H
 
+#include <stdio.h>
+#include <stdlib.h>
+
 /*
  * Lexer
  * responsible for reading source code
@@ -8,6 +11,25 @@
  *
  * it also supports push new (included) files
  */
+
+#define MAX_FILENAME_LENGTH 500
+
+struct parsing_point {
+	char tokenString[500];
+	int tokenId;
+	char filename[MAX_FILENAME_LENGTH];
+	int lineNumber;
+	int characterNumber;
+};
+
+struct file_properties {
+	FILE *f;
+	char filename[MAX_FILENAME_LENGTH];
+	int currentLineNumber;
+	int currentCharacterNumber;
+
+	struct parsing_point pointLastRead;
+};
 
 /*
  * all available tokens the lexer understands
@@ -28,32 +50,41 @@ enum lexer_tokens {
 	LEXER_TOKEN_FLOAT,
 };
 
+struct avdl_lexer {
+	int currentFile;
+	struct file_properties files[10];
+	struct parsing_point pointPrevious;
+	struct parsing_point pointCurrent;
+
+	char pastFiles[100][MAX_FILENAME_LENGTH];
+	int currentPastFile;
+};
+
 /*
- * `prepare` initialises the lexer towards the given filename.
+ * `create` initialises the lexer towards the given filename.
  * at some point `clean` should be called when the process is done.
  */
-void lexer_prepare(const char *filename);
-void lexer_clean();
+int avdl_lexer_create(struct avdl_lexer *, const char *filename);
+void avdl_lexer_clean(struct avdl_lexer *);
 
 /*
  * After initialisation, `getNextToken` will return the next
  * token.
- * In case it's not needed, `rewind` will go back one step, so
- * `getNextToken` will return the same token when called again.
  * `getLexToken` is to get the string that the token represents.
  *
  * peek is used to take a look at the next token, without
  * updating parsing position.
  */
-int lexer_getNextToken();
-int lexer_peek();
-const char *lexer_getLexToken();
+int avdl_lexer_getNextToken(struct avdl_lexer *);
+int avdl_lexer_peek(struct avdl_lexer *);
+const char *avdl_lexer_getLexToken(struct avdl_lexer *);
 
-const char *lexer_getCurrentFilename();
-int lexer_getCurrentLinenumber();
+const char *avdl_lexer_getCurrentFilename(struct avdl_lexer *);
+int avdl_lexer_getCurrentLinenumber(struct avdl_lexer *);
+int avdl_lexer_getCurrentCharacterNumber(struct avdl_lexer *);
 
-void lexer_printCurrentLine();
+void avdl_lexer_printCurrentLine(struct avdl_lexer *);
 
-void lexer_addIncludedFile(const char *includeFilename);
+int avdl_lexer_addIncludedFile(struct avdl_lexer *o, const char *includeFilename);
 
 #endif // lexer

--- a/include/avdl_semantic_analyser.h
+++ b/include/avdl_semantic_analyser.h
@@ -3,6 +3,6 @@
 
 #include "avdl_ast_node.h"
 
-void semanticAnalyser_convertToAst(struct ast_node *node, const char *filename);
+int semanticAnalyser_convertToAst(struct ast_node *node, const char *filename);
 
 #endif

--- a/src/avdl_lexer.c
+++ b/src/avdl_lexer.c
@@ -10,77 +10,67 @@
 extern char *includePath;
 
 static char buffer[500];
-static char lastTokenRead[200];
-static int lastToken;
 
-struct file_properties {
-	FILE *f;
-	char filename[200];
-	int currentLineNumber;
-	int currentCharacterNumber;
+static int avdl_lexer_includePop(struct avdl_lexer *o) {
 
-	long lex_pos_previousLine;
-	long lex_pos_currentLine;
-	long lex_pos_current;
-};
-
-static char pastFiles[100][100];
-static int currentPastFile = -1;
-static struct file_properties files[10];
-static int currentFile = -1;
-
-static void lexer_includePop(int peek) {
-
-	if (currentFile == 0) {
+	if (o->currentFile == 0) {
 		printf("lexer: attempted to pop base file\n");
-		exit(-1);
+		return -1;
 	}
 
-	if (files[currentFile].f && !peek) {
-		fclose(files[currentFile].f);
-		files[currentFile].f = 0;
+	if (o->files[o->currentFile].f) {
+		fclose(o->files[o->currentFile].f);
+		o->files[o->currentFile].f = 0;
 	}
 
-	currentFile--;
+	o->currentFile--;
+
+	// restore cache
+	strcpy(o->pointCurrent.tokenString, o->files[o->currentFile].pointLastRead.tokenString);
+	o->pointCurrent.tokenId = o->files[o->currentFile].pointLastRead.tokenId;
+	strcpy(o->pointCurrent.filename, o->files[o->currentFile].pointLastRead.filename);
+	o->pointCurrent.lineNumber = o->files[o->currentFile].pointLastRead.lineNumber;
+	o->pointCurrent.characterNumber = o->files[o->currentFile].pointLastRead.characterNumber;
+
+	return 0;
 }
 
-void lexer_prepare(const char *filename) {
-	lastTokenRead[0] = '\0';
-	lastToken = LEXER_TOKEN_UNKNOWN;
-	currentFile = 0;
-	strcpy(files[0].filename, filename);
-	files[0].currentLineNumber = 1;
-	files[0].currentCharacterNumber = 0;
+int avdl_lexer_create(struct avdl_lexer *o, const char *filename) {
 
-	files[0].f = fopen(filename, "r");
-	if (!files[0].f) {
-		printf("avdl error: Unable to open '%s': %s\n", filename, strerror(errno));
-		exit(-1);
+	if (strlen(filename) > MAX_FILENAME_LENGTH-1) {
+		printf("avdl lexer error: cannot initiate lexer, filename too big: '%s'\n", filename);
+		return -1;
+	}
+	o->currentFile = 0;
+	strcpy(o->files[0].filename, filename);
+	o->files[0].currentLineNumber = 1;
+	o->files[0].currentCharacterNumber = 1;
+
+	o->files[0].f = fopen(filename, "r");
+	if (!o->files[0].f) {
+		printf("avdl lexer error: unable to open '%s': %s\n", filename, strerror(errno));
+		return -1;
 	}
 
-	files[0].lex_pos_previousLine =
-		files[0].lex_pos_currentLine =
-			files[0].lex_pos_current =
-				ftell(files[0].f);
+	o->pointPrevious.tokenString[0] = '\0';
+	o->pointPrevious.tokenId = -1;
+	o->pointPrevious.filename[0] = '\0';
+	o->pointPrevious.lineNumber = 0;
+	o->pointPrevious.characterNumber = 1;
+
+	o->pointCurrent.tokenString[0] = '\0';
+	o->pointCurrent.tokenId = -1;
+	o->pointCurrent.filename[0] = '\0';
+	o->pointCurrent.lineNumber = 0;
+	o->pointCurrent.characterNumber = 1;
+
+	o->currentPastFile = -1;
+
+	avdl_lexer_getNextToken(o);
+	return 0;
 }
 
-void lexer_clean() {
-	for (int i = 0; i < currentFile; i++) {
-		if (files[i].f) {
-			fclose(files[i].f);
-			files[i].f = 0;
-		}
-	}
-	currentFile = -1;
-}
-
-static int getNextToken(int peek) {
-
-	files[currentFile].currentCharacterNumber += strlen(lastTokenRead);
-	if (lastToken == LEXER_TOKEN_STRING) {
-		files[currentFile].currentCharacterNumber += 2;
-	}
-	//printf("current char number += %d, %s = %d\n", strlen(buffer), buffer, files[currentFile].currentCharacterNumber);
+int avdl_lexer_getNextToken(struct avdl_lexer *o) {
 
 	// clear characters that are not tokens (whitespace / comments)
 	int allClear;
@@ -88,40 +78,45 @@ static int getNextToken(int peek) {
 		allClear = 0;
 
 		// new line
-		allClear += fscanf(files[currentFile].f, "%1[\n]", buffer);
+		allClear += fscanf(o->files[o->currentFile].f, "%1[\n]", buffer);
 		if (allClear) {
-			//printf("ignored new line\n");
-			files[currentFile].currentLineNumber++;
-			files[currentFile].currentCharacterNumber = 0;
-			files[currentFile].lex_pos_previousLine = files[currentFile].lex_pos_currentLine;
-			files[currentFile].lex_pos_currentLine = ftell(files[currentFile].f);
+			//printf("ignored new line: %d %d\n", currentFile, files[currentFile].currentLineNumber);
+			o->files[o->currentFile].currentLineNumber++;
+			o->files[o->currentFile].currentCharacterNumber = 1;
 		}
 
 		// ignore whitespace
 		buffer[0] = '\0';
-		allClear += fscanf(files[currentFile].f, "%100[ \t]*", buffer);
-		files[currentFile].currentCharacterNumber += strlen(buffer);
+		allClear += fscanf(o->files[o->currentFile].f, "%100[ \t]*", buffer);
+		o->files[o->currentFile].currentCharacterNumber += strlen(buffer);
 		//printf("ignored whitespace: %s\n", buffer);
 
 		// ignore comments
 		buffer[0] = '\0';
-		allClear += fscanf(files[currentFile].f, "%1[#]%*[^\n]*", buffer);
-		files[currentFile].currentCharacterNumber += strlen(buffer);
+		allClear += fscanf(o->files[o->currentFile].f, "%1[#]%*[^\n]*", buffer);
+		o->files[o->currentFile].currentCharacterNumber += strlen(buffer);
 		//printf("ignored comment: %s\n", buffer);
 
 		//printf("clear: %d\n", allClear);
 
 		// reached EOF in included file
-		if (feof(files[currentFile].f) && currentFile > 0) {
-			lexer_includePop(peek);
-			return lexer_getNextToken();
+		if (feof(o->files[o->currentFile].f) && o->currentFile > 0) {
+			strcpy(o->pointPrevious.tokenString, o->pointCurrent.tokenString);
+			o->pointPrevious.tokenId = o->pointCurrent.tokenId;
+			strcpy(o->pointPrevious.filename, o->pointCurrent.filename);
+			o->pointPrevious.lineNumber = o->pointCurrent.lineNumber;
+			o->pointPrevious.characterNumber = o->pointCurrent.characterNumber;
+			if (avdl_lexer_includePop(o) != 0) {
+				return -1;
+			}
+			return o->pointPrevious.tokenId;
 		}
 
 	} while (allClear > 0);
 
 	// read a character and find out what token it is
 	buffer[0] = '\0';
-	fscanf(files[currentFile].f, "%1c", buffer);
+	fscanf(o->files[o->currentFile].f, "%1c", buffer);
 	//printf("read character: %c\n", buffer[0]);
 	buffer[1] = '\0';
 
@@ -142,9 +137,9 @@ static int getNextToken(int peek) {
 	else
 	// string
 	if (buffer[0] == '\"') {
-		fscanf(files[currentFile].f, "%499[^\"]", buffer);
+		fscanf(o->files[o->currentFile].f, "%499[^\"]", buffer);
 		buffer[499] = '\0';
-		fscanf(files[currentFile].f, "%*1c");
+		fscanf(o->files[o->currentFile].f, "%*1c");
 		//printf("found string: %s\n", buffer);
 		returnToken = LEXER_TOKEN_STRING;
 	}
@@ -172,7 +167,7 @@ static int getNextToken(int peek) {
 	||  (buffer[0] >= 'A' && buffer[0] <= 'Z')
 	||   buffer[0] == '_') {
 		char restNumber[500];
-		if (fscanf(files[currentFile].f, "%500[a-zA-Z0-9_]", restNumber) > 0) {
+		if (fscanf(o->files[o->currentFile].f, "%500[a-zA-Z0-9_]", restNumber) > 0) {
 			strcat(buffer, restNumber);
 		}
 		//printf("identifier: %s\n", buffer);
@@ -185,7 +180,7 @@ static int getNextToken(int peek) {
 		// get the whole number
 		char restNumber[500];
 		restNumber[0] = '\0';
-		if (fscanf(files[currentFile].f, "%499[0-9.]", restNumber) > 0) {
+		if (fscanf(o->files[o->currentFile].f, "%499[0-9.]", restNumber) > 0) {
 			strcat(buffer, restNumber);
 		}
 
@@ -227,18 +222,10 @@ static int getNextToken(int peek) {
 
 		// check if negative number
 		if (buffer[0] == '-') {
-			long pos = ftell(files[currentFile].f);
-			char restId;
-			fscanf(files[currentFile].f, "%1c", &restId);
-			if (restId >= '0' && restId <= '9') {
-				buffer[1] = restId;
-				buffer[2] = '\0';
-				// get the whole number
-				char restNumber[500];
-				restNumber[0] = '\0';
-				if (fscanf(files[currentFile].f, "%499[0-9.]", restNumber) > 0) {
-					strcat(buffer, restNumber);
-				}
+			char restNumber[500];
+			if (fscanf(o->files[o->currentFile].f, "%499[0-9.]", restNumber) > 0) {
+				buffer[1] = '\0';
+				strcat(buffer, restNumber);
 
 				// decide if it's a floating number
 				int isFloat = 0;
@@ -253,17 +240,14 @@ static int getNextToken(int peek) {
 
 				// parsing float
 				if (isFloat) {
-					//printf("float: %s\n", buffer);
+					//printf("neg float: %s\n", buffer);
 					returnToken = LEXER_TOKEN_FLOAT;
 				}
 				// parsing int
 				else {
-					//printf("int: %s\n", buffer);
+					//printf("neg int: %s\n", buffer);
 					returnToken = LEXER_TOKEN_INT;
 				}
-			}
-			else {
-				fseek(files[currentFile].f, pos, SEEK_SET);
 			}
 		}
 		else
@@ -272,13 +256,8 @@ static int getNextToken(int peek) {
 		||  buffer[0] == '<'
 		||  buffer[0] == '>'
 		||  buffer[0] == '!') {
-			long pos = ftell(files[currentFile].f);
 			char restId;
-			fscanf(files[currentFile].f, "%1c", &restId);
-			if (restId != '=') {
-				fseek(files[currentFile].f, pos, SEEK_SET);
-			}
-			else {
+			if (fscanf(o->files[o->currentFile].f, "%1[=]", &restId)) {
 				buffer[1] = restId;
 				buffer[2] = '\0';
 			}
@@ -286,15 +265,19 @@ static int getNextToken(int peek) {
 		else
 		if (buffer[0] == '&'
 		||  buffer[0] == '|') {
-			long pos = ftell(files[currentFile].f);
 			char restId;
-			fscanf(files[currentFile].f, "%1c", &restId);
-			if (restId != buffer[0]) {
-				fseek(files[currentFile].f, pos, SEEK_SET);
+			if (buffer[0] == '&') {
+				if (fscanf(o->files[o->currentFile].f, "%1[&]", &restId)) {
+					buffer[1] = restId;
+					buffer[2] = '\0';
+				}
 			}
-			else {
-				buffer[1] = restId;
-				buffer[2] = '\0';
+			else
+			if (buffer[0] == '|') {
+				if (fscanf(o->files[o->currentFile].f, "%1[|]", &restId)) {
+					buffer[1] = restId;
+					buffer[2] = '\0';
+				}
 			}
 		}
 
@@ -305,59 +288,62 @@ static int getNextToken(int peek) {
 	}
 	else
 	// end of file -- nothing left to parse
-	if (feof(files[currentFile].f)) {
+	if (feof(o->files[o->currentFile].f)) {
 		//printf("token done\n");
 		returnToken = LEXER_TOKEN_DONE;
 	}
 
 	if (returnToken == LEXER_TOKEN_UNKNOWN) {
-		printf("unknown token: %s\n", buffer);
-		exit(-1);
+		printf("avdl: unknown token: %s\n", buffer);
+		return -1;
 	}
 
-	files[currentFile].lex_pos_current = ftell(files[currentFile].f);
+	// returnToken - token id
+	// buffer - token string
 
-	if (!peek) {
-		strncpy(lastTokenRead, buffer, 199);
-		lastTokenRead[199] = '\0';
-		lastToken = returnToken;
+	if (o->pointCurrent.tokenId != -1) {
+		strcpy(o->pointPrevious.tokenString, o->pointCurrent.tokenString);
+		o->pointPrevious.tokenId = o->pointCurrent.tokenId;
+		strcpy(o->pointPrevious.filename, o->pointCurrent.filename);
+		o->pointPrevious.lineNumber = o->pointCurrent.lineNumber;
+		o->pointPrevious.characterNumber = o->pointCurrent.characterNumber;
 	}
+	o->pointCurrent.tokenId = returnToken;
+	strcpy(o->pointCurrent.tokenString, buffer);
+	strcpy(o->pointCurrent.filename, o->files[o->currentFile].filename);
+	o->pointCurrent.lineNumber = o->files[o->currentFile].currentLineNumber;
+	o->pointCurrent.characterNumber = o->files[o->currentFile].currentCharacterNumber;
 
-	return returnToken;
-}
+	//printf("lexer %d: %s %d\n", o->currentFile, o->pointCurrent.tokenString, o->pointCurrent.tokenId);
+	//lexer_printCurrentLine();
 
-int lexer_getNextToken() {
-	return getNextToken(0);
-}
-
-int lexer_peek() {
-
-	struct file_properties files_backup[10];
-	memcpy(files_backup, files, sizeof(files_backup));
-	int currentFile_backup = currentFile;
-
-	int token = getNextToken(1);
-
-	memcpy(files, files_backup, sizeof(files_backup));
-	currentFile = currentFile_backup;
-
-	for (int i = 0; i <= currentFile; i++) {
-		fseek(files[i].f, files[i].lex_pos_current, SEEK_SET);
+	o->files[o->currentFile].currentCharacterNumber += strlen(buffer);
+	if (returnToken == LEXER_TOKEN_STRING) {
+		o->files[o->currentFile].currentCharacterNumber += 2;
 	}
+	//printf("current char number += %d, %s = %d\n", strlen(buffer), buffer, files[currentFile].currentCharacterNumber);
 
-	return token;
+	return o->pointPrevious.tokenId;
 }
 
-const char *lexer_getLexToken() {
-	return lastTokenRead;
+int avdl_lexer_peek(struct avdl_lexer *o) {
+	return o->pointCurrent.tokenId;
 }
 
-const char *lexer_getCurrentFilename() {
-	return files[currentFile].filename;
+const char *avdl_lexer_getLexToken(struct avdl_lexer *o) {
+	return o->pointPrevious.tokenString;
 }
 
-int lexer_getCurrentLinenumber() {
-	return files[currentFile].currentLineNumber;
+const char *avdl_lexer_getCurrentFilename(struct avdl_lexer *o) {
+	return o->pointPrevious.filename;
+}
+
+int avdl_lexer_getCurrentLinenumber(struct avdl_lexer *o) {
+	return o->pointPrevious.lineNumber;
+}
+
+int avdl_lexer_getCurrentCharacterNumber(struct avdl_lexer *o) {
+	return o->pointPrevious.characterNumber;
 }
 
 /*
@@ -365,52 +351,64 @@ int lexer_getCurrentLinenumber() {
  * with an arrow pointing on the first character of
  * the last parsed token
  */
-void lexer_printCurrentLine() {
+void avdl_lexer_printCurrentLine(struct avdl_lexer *o) {
 
-	// go to the line previous to the current one
-	fseek(files[currentFile].f, files[currentFile].lex_pos_previousLine, SEEK_SET);
-
-	// print the previous and current line (on first line only print that)
-	int extraLine = files[currentFile].currentLineNumber > 1 ? 1 : 0;
-	for (int i = 1 -extraLine; i < 2; i++) {
-		char b[500];
-		fscanf(files[currentFile].f, "%499[^\n]\n", b);
-		b[499] = '\0';
-		printf("   %d | %s\n", lexer_getCurrentLinenumber() -1 +i, b);
+	FILE *f = fopen(o->pointPrevious.filename, "r");
+	char b[500];
+	if (!f) {
+		printf("error error\n");
+		return;
 	}
 
-	// print an arrow pointing at the current character
-	char lineNum[20];
-	sprintf(lineNum, "%d", lexer_getCurrentLinenumber());
-	lineNum[19] = '\0';
-	printf("      ");
-	for (int i = 0; i < files[currentFile].currentCharacterNumber +strlen(lineNum); i++) {
-		printf(" ");
+	for (int i = 1; i < o->pointPrevious.lineNumber-1; i++) {
+		fgets(b, 499, f);
 	}
-	printf("^\n");
 
-	// go back to (potentially) resume parsing
-	fseek(files[currentFile].f, files[currentFile].lex_pos_current, SEEK_SET);
-}
-
-void lexer_addIncludedFile(const char *includeFilename) {
-
-	// skip files that have been included before
-	for (int i = 0; i <= currentPastFile; i++) {
-		if (strcmp(pastFiles[i], includeFilename) == 0) {
-			return;
+	//printf("avdl: error during compilation at %s:%d:%d\n", pointPrevious.filename, pointPrevious.lineNumber, pointPrevious.characterNumber);
+	for (int i = o->pointPrevious.lineNumber == 1 ? 1 : 0; i < 3; i++) {
+		fgets(b, 499, f);
+		char *p = b;
+		while (p[0] != '\0') {
+			if (p[0] == '\n' || p[0] == '\r') {
+				p[0] = '\0';
+			}
+			else
+			if (p[0] == '\t') {
+				p[0] = ' ';
+			}
+			p++;
+		}
+		printf("|%s\n", b);
+		if (i == 1) {
+			printf(" ");
+			for (int j = 0; j < o->pointPrevious.characterNumber-1; j++) {
+				printf(" ");
+			}
+			printf("^\n");
 		}
 	}
 
-	// temp limit of 100 characters per filename
-	if (strlen(includeFilename) >= 100) {
+	//printf("error: { %d %s } in %s:%d:%d\n", pointPrevious.tokenId, pointPrevious.tokenString, pointPrevious.filename, pointPrevious.lineNumber, pointPrevious.characterNumber);
+}
+
+int avdl_lexer_addIncludedFile(struct avdl_lexer *o, const char *includeFilename) {
+
+	// skip files that have been included before
+	for (int i = 0; i <= o->currentPastFile; i++) {
+		if (strcmp(o->pastFiles[i], includeFilename) == 0) {
+			return 0;
+		}
+	}
+
+	// character limit per filename
+	if (strlen(includeFilename) >= MAX_FILENAME_LENGTH-1) {
 		printf("cannot include %s: too long name\n", includeFilename);
-		exit(-1);
+		return -1;
 	}
 
 	// save included file so it's not included again
-	currentPastFile++;
-	strcpy(pastFiles[currentPastFile], includeFilename);
+	o->currentPastFile++;
+	strcpy(o->pastFiles[o->currentPastFile], includeFilename);
 
 	if (includePath) {
 		strcpy(buffer, includePath);
@@ -420,24 +418,39 @@ void lexer_addIncludedFile(const char *includeFilename) {
 		strcpy(buffer, includeFilename);
 	}
 
-	if (currentFile+1 >= 10) {
-		printf("lexer: reached limit of included files with: '%s'\n", buffer);
-		exit(-1);
+	if (o->currentFile+1 >= 10) {
+		printf("avdl: lexer: reached limit of included files with: '%s'\n", buffer);
+		return -1;
 	}
 
-	currentFile++;
-	strcpy(files[currentFile].filename, buffer);
-	files[currentFile].currentLineNumber = 1;
-	files[currentFile].currentCharacterNumber = 0;
+	// cache previous token
+	strcpy(o->files[o->currentFile].pointLastRead.tokenString, o->pointCurrent.tokenString);
+	o->files[o->currentFile].pointLastRead.tokenId = o->pointCurrent.tokenId;
+	strcpy(o->files[o->currentFile].pointLastRead.filename, o->pointCurrent.filename);
+	o->files[o->currentFile].pointLastRead.lineNumber = o->pointCurrent.lineNumber;
+	o->files[o->currentFile].pointLastRead.characterNumber = o->pointCurrent.characterNumber;
 
-	files[currentFile].f = fopen(buffer, "r");
-	if (!files[currentFile].f) {
+	o->currentFile++;
+	strcpy(o->files[o->currentFile].filename, buffer);
+	o->files[o->currentFile].currentLineNumber = 1;
+	o->files[o->currentFile].currentCharacterNumber = 0;
+
+	o->files[o->currentFile].f = fopen(buffer, "r");
+	if (!o->files[o->currentFile].f) {
 		printf("avdl error: Unable to open '%s': %s\n", buffer, strerror(errno));
-		exit(-1);
+		return -1;
 	}
 
-	files[currentFile].lex_pos_previousLine =
-		files[currentFile].lex_pos_currentLine =
-			files[currentFile].lex_pos_current =
-				ftell(files[currentFile].f);
+	avdl_lexer_getNextToken(o);
+	return 0;
+}
+
+void avdl_lexer_clean(struct avdl_lexer *o) {
+	for (int i = 0; i <= o->currentFile; i++) {
+		if (o->files[i].f) {
+			fclose(o->files[i].f);
+			o->files[i].f = 0;
+		}
+	}
+	o->currentFile = -1;
 }

--- a/src/avdl_main.c
+++ b/src/avdl_main.c
@@ -495,7 +495,9 @@ int main(int argc, char *argv[]) {
 		// initialise the parent node
 
 		game_node = ast_create(AST_GAME);
-		semanticAnalyser_convertToAst(game_node, filename[i]);
+		if (semanticAnalyser_convertToAst(game_node, filename[i]) != 0) {
+			return -1;
+		}
 
 		/*
 		 * if only transpiling, check output file

--- a/tests/avdl_lexer.test.c
+++ b/tests/avdl_lexer.test.c
@@ -1,8 +1,100 @@
 #include "avdl_symtable.h"
+#include "avdl_lexer.h"
 #include <assert.h>
 #include <stdio.h>
+#include <string.h>
+
+void expect_token(struct avdl_lexer *l, int token, const char *tokenstr, const char *filename, int lineNumber, int charNumber) {
+	assert(avdl_lexer_peek(l) == token);
+	assert(avdl_lexer_getNextToken(l) == token);
+	assert(strcmp(avdl_lexer_getLexToken(l), tokenstr) == 0);
+	assert(strcmp(avdl_lexer_getCurrentFilename(l), filename) == 0);
+	assert(avdl_lexer_getCurrentLinenumber(l) == lineNumber);
+	assert(avdl_lexer_getCurrentCharacterNumber(l) == charNumber);
+}
 
 int main(int argc, char *argv[]) {
+
+	struct avdl_lexer l;
+
+	// test a sample file
+	const char *filename = "tests/avdl_lexer_input.dd";
+	assert(avdl_lexer_create(&l, filename) == 0);
+
+	int lineCount = 0;
+	int characterCount = 0;
+
+	lineCount = 1;
+	characterCount = 1;
+	expect_token(&l, LEXER_TOKEN_COMMANDSTART, "(", filename, lineCount, characterCount);
+
+	lineCount = 1;
+	characterCount = 2;
+	expect_token(&l, LEXER_TOKEN_IDENTIFIER, "def", filename, lineCount, characterCount);
+
+	lineCount = 1;
+	characterCount = 6;
+	expect_token(&l, LEXER_TOKEN_IDENTIFIER, "int", filename, lineCount, characterCount);
+
+	lineCount = 1;
+	characterCount = 10;
+	expect_token(&l, LEXER_TOKEN_IDENTIFIER, "x", filename, lineCount, characterCount);
+
+	lineCount = 1;
+	characterCount = 11;
+	expect_token(&l, LEXER_TOKEN_COMMANDEND, ")", filename, lineCount, characterCount);
+
+	lineCount = 2;
+	characterCount = 1;
+	expect_token(&l, LEXER_TOKEN_STRING, "test string", filename, lineCount, characterCount);
+
+	lineCount = 3;
+	characterCount = 1;
+	expect_token(&l, LEXER_TOKEN_ARRAYSTART, "[", filename, lineCount, characterCount);
+
+	lineCount = 4;
+	characterCount = 1;
+	expect_token(&l, LEXER_TOKEN_ARRAYEND, "]", filename, lineCount, characterCount);
+
+	lineCount = 5;
+	characterCount = 1;
+	expect_token(&l, LEXER_TOKEN_PERIOD, ".", filename, lineCount, characterCount);
+
+	lineCount = 6;
+	characterCount = 1;
+	expect_token(&l, LEXER_TOKEN_INT, "12345", filename, lineCount, characterCount);
+
+	lineCount = 7;
+	characterCount = 1;
+	expect_token(&l, LEXER_TOKEN_FLOAT, "123.45", filename, lineCount, characterCount);
+
+	lineCount = 8;
+	characterCount = 1;
+	expect_token(&l, LEXER_TOKEN_INT, "-16", filename, lineCount, characterCount);
+
+	lineCount = 9;
+	characterCount = 1;
+	expect_token(&l, LEXER_TOKEN_FLOAT, "-11.43", filename, lineCount, characterCount);
+
+	lineCount = 10;
+	characterCount = 1;
+	expect_token(&l, LEXER_TOKEN_IDENTIFIER, "==", filename, lineCount, characterCount);
+
+	lineCount = 11;
+	characterCount = 1;
+	expect_token(&l, LEXER_TOKEN_IDENTIFIER, "&&", filename, lineCount, characterCount);
+
+	lineCount = 12;
+	characterCount = 1;
+	expect_token(&l, LEXER_TOKEN_IDENTIFIER, "||", filename, lineCount, characterCount);
+
+	avdl_lexer_clean(&l);
+
+	// test error values
+	char hugefilename[MAX_FILENAME_LENGTH+1];
+	memset(hugefilename, 'a', MAX_FILENAME_LENGTH);
+	hugefilename[MAX_FILENAME_LENGTH] = '\0';
+	assert(avdl_lexer_create(&l, hugefilename) != 0);
 
 	return 0;
 }

--- a/tests/avdl_lexer_input.dd
+++ b/tests/avdl_lexer_input.dd
@@ -1,0 +1,12 @@
+(def int x) # a normal command
+"test string" # strings
+[ # start of array
+] # end of array
+. # special dot
+12345 # integer
+123.45 # float
+-16 # negative int
+-11.43 # negative float
+== # special commands
+&&
+||


### PR DESCRIPTION
## Description

Re-organised lexer to stop using `ftell` and `fseek`, as that functionality seems to be buggy on windows when parsing unix files (with `\n` instead of `\r\n`).

Also made the lexer a bit more module and wrote an initial test for it.